### PR TITLE
Fix checkbox behavior to reset var when unchecked

### DIFF
--- a/version-history.txt
+++ b/version-history.txt
@@ -1,3 +1,5 @@
+1.3.2 - Fix checkbox behavior to reset var when unchecked
+
 1.3.1 - Fix missing write callbacks for root variables
 
 1.3.0 - Synchronize release version with OMJSON

--- a/webhmi-data-bind.js
+++ b/webhmi-data-bind.js
@@ -804,7 +804,7 @@ WEBHMI.addVarWriteEvents = function () {
 				if ($this.prop('checked')) {
 					localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
 				} else {
-					localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this)); //TODO: This can't be right...
+					localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getResetValue($this));
 				}
 			}
 		},


### PR DESCRIPTION
# What

Fixes logic so that when checkbox is unchecked, it resets the connected variable to 0.

# Why

Because it was incorrect.