### PR TITLE
Feature/fix copy paste

### DIFF
--- a/webhmi-ext.js
+++ b/webhmi-ext.js
@@ -53,7 +53,6 @@ $(document).on({
             var menu = new Menu()
             var $this = $(this);
             var datavarname = $this.attr('data-var-name');
-            const element = $('<textarea ></textarea>');
 
             menu.append(new MenuItem({
                 label: 'Paste',
@@ -69,12 +68,24 @@ $(document).on({
             menu.append(new MenuItem({
                 label: 'Copy PV',
                 click() {
-                    $this.append(element);
-                    element.text(datavarname);
-                    element.focus();
-                    element[0].setSelectionRange(0, datavarname.length);
-                    document.execCommand('copy');
-                    element.remove();
+                    if (navigator.clipboard) {
+                        navigator.clipboard.writeText(datavarname);
+                    }
+                    else{
+                        let pos = $this.offset();
+                        const element = $('<textarea ></textarea>');
+                        $('body').append(element);
+                        element.text(datavarname);
+                        element.css({
+                            position: "absolute",
+                            top: pos.top + "px",
+                            left: pos.left + "px"
+                        })
+                        element.focus();
+                        element[0].setSelectionRange(0, datavarname.length);
+                        document.execCommand('copy');
+                        element.remove();
+                    }
                     console.log(datavarname)
                 }
             }))


### PR DESCRIPTION
# What
Make PV copy / paste behavior more robust by forcing the copied element to be selectable.
This fix was discovered by @Joshpolansky and @JcJakeway in a different repo, I'm just bringing it over here and adding navigator paste. 

I have not tested this.

# Why
Some nested or covered elements can prevent copy from correctly working. One of our users reported that copy/paste wouldn't work for certain elements of their UI.