### PR TITLE
Get jquery from cypress when running in cy context

### DIFF
--- a/src/HMI/webhmi.js
+++ b/src/HMI/webhmi.js
@@ -23,14 +23,32 @@ var jQueryImport;
 // jQuery polyfills - Later
 if (typeof jQuery === 'undefined') {
 
-	try {
+	if (typeof module !== 'undefined' && module.exports) {
 		
-		// appease jenkins if possible
-		// jest runs tests in a node environment without the wrapping app that "includes" jQuery
-		jQueryImport = require('jquery');
+		// we are running in a node js environment
+		
+		try {
+			
+			// appease jenkins if possible
+			// jest runs tests in a node environment without the wrapping app that "includes" jQuery
+			jQueryImport = require('jquery');
 
-	} catch {
-		throw new Error('Polyfill not done! Get jQuery!');
+		} catch {
+			throw new Error('Polyfill not done! Get jQuery!');
+		}
+
+	} else {
+		
+		// we are not running in a node js environment
+
+		// try getting jquery from cypress
+		if (typeof Cypress === 'undefined') {
+			throw new Error('Polyfill not done! Get jQuery!');
+		} else {
+			jQueryImport = Cypress.$
+			window.$ = window.jQuery = Cypress.$
+		}
+		
 	}
 
 } else {


### PR DESCRIPTION
This change allows you to instantiate a webhmi machine within the cypress testing context.
Having a webhmi machine in the cypress testing context is useful for forcing IO or initiating commands that aren't available through the DOM.
The concept is well tested, but this particular implementation is not - the nodejs check and jQueryImport var are new.