### PR TITLE
Invalidate cached value for elements after write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+2.0.1 - Fix issue where writing a value to the PLC would not update the HMI if the value was clamped on the PLC to the current value
+
 2.0.0 - Transition webHMI name to Lux / Loupe UX
 
 1.6.0 - Add read groups attribute to support more sophisticated machine variable reads with frequency limits and callbacks

--- a/src/HMI/lux-data-bind.js
+++ b/src/HMI/lux-data-bind.js
@@ -717,8 +717,10 @@ LUX.addVarWriteEvents = function () {
 				var $this = $(this);
 				var localMachine = window[LUX.getMachineName($this)];
 				localMachine.writeVariable(LUX.getVarName($this), LUX.getSetValue($this));
+				$this.removeAttr('data-machine-value');
 				$this.one('mouseleave', function () {
 					localMachine.writeVariable(LUX.getVarName($this), LUX.getResetValue($this));
+					$this.removeAttr('data-machine-value');
 					$this.blur();
 				});
 			},
@@ -727,6 +729,7 @@ LUX.addVarWriteEvents = function () {
 				var $this = $(this);
 				var localMachine = window[LUX.getMachineName($this)];
 				localMachine.writeVariable(LUX.getVarName($this), LUX.getResetValue($this));
+				$this.removeAttr('data-machine-value');
 				$this.blur();
 				$this.off('mouseleave');
 			},
@@ -736,6 +739,7 @@ LUX.addVarWriteEvents = function () {
 				var $this = $(this);
 				var localMachine = window[LUX.getMachineName($this)];
 				localMachine.writeVariable(LUX.getVarName($this), LUX.getSetValue($this));
+				$this.removeAttr('data-machine-value');
 				//$this.one('touchleave', function(){$this.trigger('touchend');});
 			},
 
@@ -744,6 +748,7 @@ LUX.addVarWriteEvents = function () {
 				var $this = $(this);
 				var localMachine = window[LUX.getMachineName($this)];
 				localMachine.writeVariable(LUX.getVarName($this), LUX.getResetValue($this));
+				$this.removeAttr('data-machine-value');
 				$this.blur();
 				//This is not required because touchend is triggered when the touch leaves the element
 				//$this.off('touchleave');
@@ -764,10 +769,12 @@ LUX.addVarWriteEvents = function () {
 				if ($this.hasClass("lux-confirm")) {
 					LuxConfirmModal('Do you want to "' + $this.context.innerHTML + '"?', function () {
 						localMachine.writeVariable(LUX.getVarName($this), LUX.getSetValue($this));
+						$this.removeAttr('data-machine-value');
 					})
 				}
 				else {
 					localMachine.writeVariable(LUX.getVarName($this), LUX.getSetValue($this));
+					$this.removeAttr('data-machine-value');
 				}
 			}
 		},
@@ -839,7 +846,7 @@ LUX.addVarWriteEvents = function () {
 						} else {
 							localMachine.writeVariable(LUX.getVarName($this), LUX.getSetValue($this));
 						}
-
+						$this.removeAttr('data-machine-value');
 						$this.blur();
 					})
 				}
@@ -853,7 +860,7 @@ LUX.addVarWriteEvents = function () {
 					} else {
 						localMachine.writeVariable(LUX.getVarName($this), LUX.getSetValue($this));
 					}
-
+					$this.removeAttr('data-machine-value');
 					$this.blur();
 				}
 			}
@@ -876,6 +883,7 @@ LUX.addVarWriteEvents = function () {
 				} else {
 					localMachine.writeVariable(LUX.getVarName($this), LUX.getResetValue($this));
 				}
+				$this.removeAttr('data-machine-value');
 			}
 		},
 		'input:checkbox.lux-checkbox');
@@ -931,6 +939,7 @@ LUX.addVarWriteEvents = function () {
 
 				var localMachine = window[LUX.getMachineName($this)];
 				localMachine.writeVariable(LUX.getVarName($this), varValue);
+				$this.removeAttr('data-machine-value');
 				$this.blur();
 
 			}
@@ -991,6 +1000,7 @@ LUX.addVarWriteEvents = function () {
 
 				var localMachine = window[LUX.getMachineName($this)];
 				localMachine.writeVariable(LUX.getVarName($this), varValue);
+				$this.removeAttr('data-machine-value');
 				$this.blur();
 
 			}
@@ -1006,6 +1016,7 @@ LUX.addVarWriteEvents = function () {
 				var localMachine = window[LUX.getMachineName($this)];
 				localMachine.writeVariable(LUX.getVarName($this), $this.val());
 				localMachine.readVariable(LUX.getVarName($this));
+				$this.removeAttr('data-machine-value');
 			}
 		},
 		'input.lux-text-value, invisible-input.lux-text-value, textarea.lux-text-value');
@@ -1018,6 +1029,7 @@ LUX.addVarWriteEvents = function () {
 				var localMachine = window[LUX.getMachineName($this)];
 				localMachine.writeVariable(LUX.getVarName($this), $this[0].options.selectedIndex);
 				localMachine.readVariable(LUX.getVarName($this));
+				$this.removeAttr('data-machine-value');
 			}
 		},
 		'.lux-dropdown');

--- a/src/HMI/package.json
+++ b/src/HMI/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loupeteam/loupe-ux",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The Loupe UX javascript library provides functionality for implementing a web-based HMI for machines",
   "main": "lux.js",
   "scripts": {


### PR DESCRIPTION
# What 

Invalidate the data-machine-value on an element after the PLC value was written

# Why

We cache the previous PLC value in the HMI updates to avoid re-rendering values that haven't changed. When you write a value down to the PLC we weren't modifying that value. In most cases this was fine, because the value is changed, the element detects the change after a read and the element updates itself. 

The problem occurs when you write a value to the plc, and the PLC caps the value. So for example:

normal: 
|  state  | html  | previous value  | PLC |
|---|---|---| -- |
| start  | 200  | 200  |  200 |   
|  edit | 300  | 200  |   200 |  
|  write| 300  | 200  |   300 |  
|  read | 300  | 200  |  300 |

Limiting
|  state  | html  | previous value  | PLC |
|---|---|---| -- |
| start  | 200  | 200  |  200 |   
|  edit | 300  | 200  |   200 |  
|  write| 300  | 200  |   200 |  
|  read | 300  | 200  |  200 | 