### PR TITLE
Invalidate cached value for elements after write

### DIFF
--- a/src/HMI/package.json
+++ b/src/HMI/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loupeteam/webhmi",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "The Loupe webHMI javascript library provides functionality for implementing a web-based HMI for machines",
   "main": "webhmi.js",
   "scripts": {

--- a/src/HMI/version-history.txt
+++ b/src/HMI/version-history.txt
@@ -1,3 +1,5 @@
+1.6.3 - Fix issue where writing a value to the PLC would not update the HMI if the value was clamped on the PLC to the current value
+
 1.6.2 - Fix momentary button behavior when the user leaves an element while holding the mouse down
 
 1.6.1 - Add read group functions to local HMI machine

--- a/src/HMI/webhmi-data-bind.js
+++ b/src/HMI/webhmi-data-bind.js
@@ -304,6 +304,15 @@ WEBHMI.getCyclicReads = function () {
 	});
 }
 
+WEBHMI.writeValueFromElement = function ($this, value) {
+	var localMachine = window[WEBHMI.getMachineName($this)];
+	let VariableName = WEBHMI.getVarName($this);
+	localMachine.writeVariable(VariableName, value);
+	localMachine.value(VariableName, value);
+	localMachine.readVariable(VariableName);
+	$this.attr('data-machine-value', value);
+}
+
 // Update ReadGroup elements
 //----------------------
 
@@ -710,21 +719,16 @@ WEBHMI.addVarWriteEvents = function () {
 		{
 			mousedown: function (event) {
 				var $this = $(this);
-				var localMachine = window[WEBHMI.getMachineName($this)];
-				localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
-				$this.removeAttr('data-machine-value');
+				WEBHMI.writeValueFromElement($this, WEBHMI.getSetValue($this));
 				$this.one('mouseleave', function () {
-					localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getResetValue($this));
-					$this.removeAttr('data-machine-value');
+					WEBHMI.writeValueFromElement($this, WEBHMI.getResetValue($this));
 					$this.blur();
 				});
 			},
 
 			mouseup: function (event) {
 				var $this = $(this);
-				var localMachine = window[WEBHMI.getMachineName($this)];
-				localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getResetValue($this));
-				$this.removeAttr('data-machine-value');
+				WEBHMI.writeValueFromElement($this, WEBHMI.getResetValue($this));
 				$this.blur();
 				$this.off('mouseleave');
 			},
@@ -732,8 +736,7 @@ WEBHMI.addVarWriteEvents = function () {
 			touchstart: function (event) {
 				event.preventDefault();
 				var $this = $(this);
-				var localMachine = window[WEBHMI.getMachineName($this)];
-				localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
+				WEBHMI.writeValueFromElement($this, WEBHMI.getSetValue($this));
 				//This is not required because touchend is triggered when the touch leaves the element
 				$this.removeAttr('data-machine-value');
 				//$this.one('touchleave', function(){$this.trigger('touchend');});
@@ -742,9 +745,7 @@ WEBHMI.addVarWriteEvents = function () {
 			touchend: function (event) {
 				event.preventDefault();
 				var $this = $(this);
-				var localMachine = window[WEBHMI.getMachineName($this)];
-				localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getResetValue($this));
-				$this.removeAttr('data-machine-value');
+				WEBHMI.writeValueFromElement($this, WEBHMI.getResetValue($this));
 				$this.blur();
 				//This is not required because touchend is triggered when the touch leaves the element
 				//$this.off('touchleave');
@@ -764,13 +765,11 @@ WEBHMI.addVarWriteEvents = function () {
 				}
 				if ($this.hasClass("webhmi-confirm")) {
 					WebhmiConfirmModal('Do you want to "' + $this.context.innerHTML + '"?', function () {
-						localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
-						$this.removeAttr('data-machine-value');
+						WEBHMI.writeValueFromElement($this, WEBHMI.getSetValue($this));
 					})
 				}
 				else {
-					localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
-					$this.removeAttr('data-machine-value');
+					WEBHMI.writeValueFromElement($this, WEBHMI.getSetValue($this));
 				}
 			}
 		},
@@ -836,13 +835,12 @@ WEBHMI.addVarWriteEvents = function () {
 						var varValue = WEBHMI.getValue($this);
 
 						if (isEqual(varValue, WEBHMI.getSetValue($this))) {
-							localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getResetValue($this));
+							WEBHMI.writeValueFromElement($this, WEBHMI.getResetValue($this));
 						} else if (isEqual(varValue, WEBHMI.getResetValue($this))) {
-							localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
+							WEBHMI.writeValueFromElement($this, WEBHMI.getSetValue($this));
 						} else {
-							localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
+							WEBHMI.writeValueFromElement($this, WEBHMI.getSetValue($this));
 						}
-						$this.removeAttr('data-machine-value');
 						$this.blur();
 					})
 				}
@@ -850,13 +848,12 @@ WEBHMI.addVarWriteEvents = function () {
 					var varValue = WEBHMI.getValue($this);
 
 					if (isEqual(varValue, WEBHMI.getSetValue($this))) {
-						localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getResetValue($this));
+						WEBHMI.writeValueFromElement($this, WEBHMI.getResetValue($this));
 					} else if (isEqual(varValue, WEBHMI.getResetValue($this))) {
-						localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
+						WEBHMI.writeValueFromElement($this, WEBHMI.getSetValue($this));
 					} else {
-						localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
+						WEBHMI.writeValueFromElement($this, WEBHMI.getSetValue($this));
 					}
-					$this.removeAttr('data-machine-value');
 					$this.blur();
 				}
 			}
@@ -872,14 +869,12 @@ WEBHMI.addVarWriteEvents = function () {
 				// So, checkboxes do not behave like toggles.
 
 				var $this = $(this);
-				var localMachine = window[WEBHMI.getMachineName($this)];
 
 				if ($this.prop('checked')) {
-					localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
+					WEBHMI.writeValueFromElement($this, WEBHMI.getSetValue($this));
 				} else {
-					localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getResetValue($this));
+					WEBHMI.writeValueFromElement($this, WEBHMI.getResetValue($this));
 				}
-				$this.removeAttr('data-machine-value');
 			}
 		},
 		'input:checkbox.webhmi-checkbox');
@@ -933,9 +928,7 @@ WEBHMI.addVarWriteEvents = function () {
 					}
 				}
 
-				var localMachine = window[WEBHMI.getMachineName($this)];
-				localMachine.writeVariable(WEBHMI.getVarName($this), varValue);
-				$this.removeAttr('data-machine-value');
+				WEBHMI.writeValueFromElement($this, varValue);				
 				$this.blur();
 
 			}
@@ -994,9 +987,7 @@ WEBHMI.addVarWriteEvents = function () {
 					}
 				}
 
-				var localMachine = window[WEBHMI.getMachineName($this)];
-				localMachine.writeVariable(WEBHMI.getVarName($this), varValue);
-				$this.removeAttr('data-machine-value');
+				WEBHMI.writeValueFromElement($this, varValue);
 				$this.blur();
 
 			}
@@ -1009,10 +1000,7 @@ WEBHMI.addVarWriteEvents = function () {
 		{
 			change: function (event) {
 				var $this = $(this);
-				var localMachine = window[WEBHMI.getMachineName($this)];
-				localMachine.writeVariable(WEBHMI.getVarName($this), $this.val());
-				localMachine.readVariable(WEBHMI.getVarName($this));
-				$this.removeAttr('data-machine-value');
+				WEBHMI.writeValueFromElement($this, $this.val());
 			}
 		},
 		'input.webhmi-text-value, invisible-input.webhmi-text-value, textarea.webhmi-text-value');
@@ -1022,10 +1010,7 @@ WEBHMI.addVarWriteEvents = function () {
 		{
 			change: function (event) {
 				var $this = $(this);
-				var localMachine = window[WEBHMI.getMachineName($this)];
-				localMachine.writeVariable(WEBHMI.getVarName($this), $this[0].options.selectedIndex);
-				localMachine.readVariable(WEBHMI.getVarName($this));
-				$this.removeAttr('data-machine-value');
+				WEBHMI.writeValueFromElement($this, $this[0].options.selectedIndex);
 			}
 		},
 		'.webhmi-dropdown');

--- a/src/HMI/webhmi-data-bind.js
+++ b/src/HMI/webhmi-data-bind.js
@@ -712,8 +712,10 @@ WEBHMI.addVarWriteEvents = function () {
 				var $this = $(this);
 				var localMachine = window[WEBHMI.getMachineName($this)];
 				localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
+				$this.removeAttr('data-machine-value');
 				$this.one('mouseleave', function () {
 					localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getResetValue($this));
+					$this.removeAttr('data-machine-value');
 					$this.blur();
 				});
 			},
@@ -722,6 +724,7 @@ WEBHMI.addVarWriteEvents = function () {
 				var $this = $(this);
 				var localMachine = window[WEBHMI.getMachineName($this)];
 				localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getResetValue($this));
+				$this.removeAttr('data-machine-value');
 				$this.blur();
 				$this.off('mouseleave');
 			},
@@ -732,6 +735,7 @@ WEBHMI.addVarWriteEvents = function () {
 				var localMachine = window[WEBHMI.getMachineName($this)];
 				localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
 				//This is not required because touchend is triggered when the touch leaves the element
+				$this.removeAttr('data-machine-value');
 				//$this.one('touchleave', function(){$this.trigger('touchend');});
 			},
 
@@ -740,6 +744,7 @@ WEBHMI.addVarWriteEvents = function () {
 				var $this = $(this);
 				var localMachine = window[WEBHMI.getMachineName($this)];
 				localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getResetValue($this));
+				$this.removeAttr('data-machine-value');
 				$this.blur();
 				//This is not required because touchend is triggered when the touch leaves the element
 				//$this.off('touchleave');
@@ -760,10 +765,12 @@ WEBHMI.addVarWriteEvents = function () {
 				if ($this.hasClass("webhmi-confirm")) {
 					WebhmiConfirmModal('Do you want to "' + $this.context.innerHTML + '"?', function () {
 						localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
+						$this.removeAttr('data-machine-value');
 					})
 				}
 				else {
 					localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
+					$this.removeAttr('data-machine-value');
 				}
 			}
 		},
@@ -835,7 +842,7 @@ WEBHMI.addVarWriteEvents = function () {
 						} else {
 							localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
 						}
-
+						$this.removeAttr('data-machine-value');
 						$this.blur();
 					})
 				}
@@ -849,7 +856,7 @@ WEBHMI.addVarWriteEvents = function () {
 					} else {
 						localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getSetValue($this));
 					}
-
+					$this.removeAttr('data-machine-value');
 					$this.blur();
 				}
 			}
@@ -872,6 +879,7 @@ WEBHMI.addVarWriteEvents = function () {
 				} else {
 					localMachine.writeVariable(WEBHMI.getVarName($this), WEBHMI.getResetValue($this));
 				}
+				$this.removeAttr('data-machine-value');
 			}
 		},
 		'input:checkbox.webhmi-checkbox');
@@ -927,6 +935,7 @@ WEBHMI.addVarWriteEvents = function () {
 
 				var localMachine = window[WEBHMI.getMachineName($this)];
 				localMachine.writeVariable(WEBHMI.getVarName($this), varValue);
+				$this.removeAttr('data-machine-value');
 				$this.blur();
 
 			}
@@ -987,6 +996,7 @@ WEBHMI.addVarWriteEvents = function () {
 
 				var localMachine = window[WEBHMI.getMachineName($this)];
 				localMachine.writeVariable(WEBHMI.getVarName($this), varValue);
+				$this.removeAttr('data-machine-value');
 				$this.blur();
 
 			}
@@ -1002,6 +1012,7 @@ WEBHMI.addVarWriteEvents = function () {
 				var localMachine = window[WEBHMI.getMachineName($this)];
 				localMachine.writeVariable(WEBHMI.getVarName($this), $this.val());
 				localMachine.readVariable(WEBHMI.getVarName($this));
+				$this.removeAttr('data-machine-value');
 			}
 		},
 		'input.webhmi-text-value, invisible-input.webhmi-text-value, textarea.webhmi-text-value');
@@ -1014,6 +1025,7 @@ WEBHMI.addVarWriteEvents = function () {
 				var localMachine = window[WEBHMI.getMachineName($this)];
 				localMachine.writeVariable(WEBHMI.getVarName($this), $this[0].options.selectedIndex);
 				localMachine.readVariable(WEBHMI.getVarName($this));
+				$this.removeAttr('data-machine-value');
 			}
 		},
 		'.webhmi-dropdown');


### PR DESCRIPTION
# What 

Invalidate the data-machine-value on an element after the PLC value was written

# Why

We cache the previous PLC value in the HMI updates to avoid re-rendering values that haven't changed. When you write a value down to the PLC we weren't modifying that value. In most cases this was fine, because the value is changed, the element detects the change after a read and the element updates itself. 

The problem occurs when you write a value to the plc, and the PLC caps the value. So for example:

normal: 
|  state  | html  | previous value  | PLC |
|---|---|---| -- |
| start  | 200  | 200  |  200 |   
|  edit | 300  | 200  |   200 |  
|  write| 300  | 200  |   300 |  
|  read | 300  | 200  |  300 |

Limiting
|  state  | html  | previous value  | PLC |
|---|---|---| -- |
| start  | 200  | 200  |  200 |   
|  edit | 300  | 200  |   200 |  
|  write| 300  | 200  |   200 |  
|  read | 300  | 200  |  200 | 