### PR TITLE
Fix recursive change event

### DIFF
--- a/src/HMI/package.json
+++ b/src/HMI/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loupeteam/webhmi",
-  "version": "1.7.0-rc.1",
+  "version": "1.7.0",
   "description": "The Loupe webHMI javascript library provides functionality for implementing a web-based HMI for machines",
   "main": "webhmi.js",
   "scripts": {

--- a/src/HMI/package.json
+++ b/src/HMI/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loupeteam/webhmi",
-  "version": "1.6.2",
+  "version": "1.7.0-rc.1",
   "description": "The Loupe webHMI javascript library provides functionality for implementing a web-based HMI for machines",
   "main": "webhmi.js",
   "scripts": {

--- a/src/HMI/webhmi-data-bind.js
+++ b/src/HMI/webhmi-data-bind.js
@@ -1259,22 +1259,29 @@ $(document).one({
 
 //This element can be used to catch value changed events on elements that wouldn't normally have an "Input"
 class invisibleInput extends HTMLElement {
-    constructor() {
-        super()
-		this.setAttribute('force-hmi-update',true)
-    }
-    set value( v ){
-        this._value = v
-        this.setAttribute('value', v)
+	constructor() {
+		super()
+		this.setAttribute('force-hmi-update', true)
+	}
+	set value(v) {
+		this._value = v
+		this.setAttribute('value', v)
+		this._render()
+	}
+	get value() {
+		return this._value || 0
+	}
+	_render() {
 		let evt = new Event("render", {
-            "bubbles": true,
-            "cancelable": true
-        });
-        this.dispatchEvent(evt);
-    }
-    get value( ){
-        return this._value || 0
-    }
+			"bubbles": true,
+			"cancelable": true
+		});
+		this.dispatchEvent(evt);
+		this.render()
+	}
+	render() {
+
+	}
 }
       
 customElements.define('invisible-input', invisibleInput);

--- a/src/HMI/webhmi-data-bind.js
+++ b/src/HMI/webhmi-data-bind.js
@@ -1266,7 +1266,7 @@ class invisibleInput extends HTMLElement {
     set value( v ){
         this._value = v
         this.setAttribute('value', v)
-        let evt = new Event("change", {
+		let evt = new Event("render", {
             "bubbles": true,
             "cancelable": true
         });

--- a/src/HMI/webhmi-data-bind.js
+++ b/src/HMI/webhmi-data-bind.js
@@ -1269,7 +1269,12 @@ class invisibleInput extends HTMLElement {
 		this._render()
 	}
 	get value() {
-		return this._value || 0
+		if(this._value === undefined){
+			return 0;
+		}
+		else{
+			return this._value
+		}
 	}
 	_render() {
 		let evt = new Event("render", {


### PR DESCRIPTION
# What

Changes the "change" event on the invisible input to a custom "render" event

# Why

The invisible input is meant to be a placeholder for values that can trigger re-rendering on other elements that use it when the value is changed. This had overloaded the change event to do so, so when the value was set you could get stuck in an on change loop. 

The intention of the element is to re-render a visual element when the value is changed. I think this should actually call a render method on itself AND call this event, so that a user could extent this element directly if they wanted. 

# Migration

This will require updating some tmplits that use the change event to use a new render event.

This is the current relationship
```html
<custom-element onchange=(val)->{ invisible-input.value=val } >
 <invisible-input change= () -> { parent->change() } >
</custom-element>
```
This is the proposed relationship
```html
<custom-element onchange=(val)->{ invisible-input.value=val } >
 <invisible-input render= () -> { parent->render() } >
</custom-element>
```
