### PR TITLE
Fix undefined in data read groups

### DIFF
--- a/src/HMI/lux-data-bind.js
+++ b/src/HMI/lux-data-bind.js
@@ -1083,12 +1083,15 @@ LUX.addVarWriteEvents = function () {
 
 };
 LUX.updateReadGroupComms = function () {
-	if(readGroups.length == 1 && readGroups[0] === 'global') {
-		// This is a short circuit to save time, getting read group elements is expensive
+	if(LUX.machines.every(machine => {
+		const readGroups = machine.getReadGroupList();
+		return (readGroups.length == 1 && readGroups[0] === 'global') // This is a short circuit to save time, getting read group elements is expensive
+		})) {
 		return;
 	}
 	const readGroupElements = new Set(Array.from(document.querySelectorAll('[data-read-group]')).map(el => el.getAttribute('data-read-group')));
 	LUX.machines.forEach(machine => {
+		let readGroups = machine.getReadGroupList()
 		readGroups.forEach(ReadGroupName => {
 			if (ReadGroupName !== 'global') {
 				machine.readGroupShouldManage(ReadGroupName, readGroupElements.has(ReadGroupName));


### PR DESCRIPTION
## What:

Fixes error undefined `readGroups` in LUX DataBinding. This was introduced in `v2.0.3`

```js
lux-data-bind.js:1086 Uncaught ReferenceError: readGroups is not defined
    at Object.LUX.updateReadGroupComms (lux-data-bind.js:1086)
    at LUX.updateHMI (lux-data-bind.js:1189)
```

## Why:

The previous version breaks read groups
